### PR TITLE
Fix Money Display printing a negative sign for zero amounts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use exchange::ExchangeRate;
 use fpdec::{DivRounded, MulRounded, Round};
 pub use iso_4217::ISOCurrency;
 pub use quantities::{
-    Amnt, AmountT, Dec, Decimal, Quantity, Rate, SIPrefix, Unit,
+    AMNT_ZERO, Amnt, AmountT, Dec, Decimal, Quantity, Rate, SIPrefix, Unit,
 };
 
 mod currency;
@@ -698,7 +698,7 @@ impl fmt::Display for Money {
     /// ```
     fn fmt(&self, form: &mut fmt::Formatter<'_>) -> fmt::Result {
         let tmp: String;
-        let amnt_non_neg = self.amount().is_positive();
+        let amnt_non_neg = self.amount() >= AMNT_ZERO;
         let abs_amnt = self.amount().abs();
         if let Some(prec) = form.precision() {
             tmp = format!("{:.*} {}", prec, abs_amnt, self.unit());

--- a/tests/test_money.rs
+++ b/tests/test_money.rs
@@ -53,6 +53,95 @@ mod test_money_formatting {
 }
 
 #[cfg(test)]
+mod test_money_zero_sign {
+    use moneta::{Dec, Decimal, Money, Quantity, EUR, USD, UYW, VUV};
+    use quantities::prelude::*;
+
+    // A generic quantity, used as the reference oracle: the crate-level
+    // `Quantity` Display (in the `quantities` crate) is the behaviour
+    // `Money`'s own Display is meant to mirror.
+    #[quantity]
+    #[ref_unit(Kilogram, "kg", KILO, "ref")]
+    #[unit(Gram, "g", NONE, 0.001, "0.001 kg")]
+    struct Mass {}
+
+    // A zero amount has no sign, so its formatted form must never start
+    // with '-', and the '+' flag must yield '+', not '-'.
+    #[test]
+    fn test_zero_has_no_negative_sign() {
+        let zero = Money::new(Dec!(0.00), EUR);
+        assert_eq!(zero.to_string(), "0.00 EUR");
+        assert_eq!(format!("{}", zero), "0.00 EUR");
+        assert_eq!(format!("{:+}", zero), "+0.00 EUR");
+        assert_eq!(format!("{: }", zero), "0.00 EUR");
+        // Minor unit other than 2 (UYW: 4, VUV: 0).
+        assert_eq!((Dec!(0) * UYW).to_string(), "0.0000 UYW");
+        assert_eq!(format!("{:+}", Dec!(0) * VUV), "+0 VUV");
+    }
+
+    // Zero reached by arithmetic must format identically to a literal zero;
+    // the amount type has no negative zero to leak a stray sign.
+    #[test]
+    fn test_arithmetic_zero_has_no_sign() {
+        let sub = Dec!(5.00) * EUR - Dec!(5.00) * EUR;
+        assert_eq!(sub.to_string(), "0.00 EUR");
+        let neg_times_zero = Dec!(-1) * (Dec!(0.00) * EUR);
+        assert_eq!(neg_times_zero.to_string(), "0.00 EUR");
+    }
+
+    // Width, fill, precision and the '+' flag all compose correctly on zero.
+    #[test]
+    fn test_zero_with_format_spec() {
+        let zero = Money::new(Dec!(0.00), EUR);
+        assert_eq!(format!("{:*>+12.2}", zero), "***+0.00 EUR");
+        assert_eq!(format!("{:>10.0}", zero), "     0 EUR");
+        assert_eq!(format!("{:<+15.4}", zero), "+0.0000 EUR    ");
+    }
+
+    // Non-zero values keep their sign (regression guard for the fix).
+    #[test]
+    fn test_nonzero_sign_unchanged() {
+        assert_eq!((Dec!(12.50) * EUR).to_string(), "12.50 EUR");
+        assert_eq!((Dec!(-12.50) * EUR).to_string(), "-12.50 EUR");
+        assert_eq!(format!("{:+}", Dec!(12.50) * EUR), "+12.50 EUR");
+        // A truly negative amount that rounds to zero only at the requested
+        // display precision keeps its sign (taken from the real value).
+        let small_neg = Money::new(Dec!(-0.01), EUR);
+        assert_eq!(format!("{:.1}", small_neg), "-0.0 EUR");
+        assert_eq!(format!("{:.0}", small_neg), "-0 EUR");
+    }
+
+    // Leading sign character produced by a formatted value, or None.
+    fn sign_of(s: &str) -> Option<char> {
+        match s.chars().next() {
+            Some(c @ ('+' | '-')) => Some(c),
+            _ => None,
+        }
+    }
+
+    // `Money` Display must agree with the generic `Quantity` Display on the
+    // sign it emits for every amount, with and without the '+' flag.
+    #[test]
+    fn test_sign_parity_with_generic_quantity() {
+        let amounts = [Dec!(0), Dec!(12.50), Dec!(-12.50), Dec!(0.30)];
+        for a in amounts {
+            let money = a * USD;
+            let qty = a * KILOGRAM;
+            assert_eq!(
+                sign_of(&format!("{}", money)),
+                sign_of(&format!("{}", qty)),
+                "plain sign mismatch for {a}"
+            );
+            assert_eq!(
+                sign_of(&format!("{:+}", money)),
+                sign_of(&format!("{:+}", qty)),
+                "'+' sign mismatch for {a}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod test_money_ops {
     use moneta::{Dec, Decimal, Quantity, USD, UYW};
 


### PR DESCRIPTION
### Problem

`impl fmt::Display for Money` derives its sign flag from
`self.amount().is_positive()` (src/lib.rs:701). `is_positive()` is `false`
for zero, so `pad_integral` is told the value is negative and prefixes a `-`:

```rust
let z = Money::new(Dec!(0.00), EUR);
format!("{}", z);    // "-0.00 EUR"   (expected "0.00 EUR")
format!("{:+}", z);  // "-0.00 EUR"   (expected "+0.00 EUR")
```

A zero amount has no sign, so the `-` (and the inverted `+` flag) are wrong.
The amount type has no negative zero, so a zero reached by arithmetic
(`x - x`, `Dec!(-1) * zero`) hits the same path and prints `-0.00` too.

### Fix

Use `self.amount() >= AMNT_ZERO` for the sign flag. This is exactly the guard
the generic `Quantity` Display already uses in the `quantities` crate
(src/lib.rs:358) — `Money`'s Display was an inlined copy that regressed the
guard to `is_positive()` when it stopped delegating to `<Self as Quantity>::fmt`.
Zero is now treated as non-negative; genuine negative amounts keep their sign,
including one that rounds to zero only at the requested display precision
(`format!("{:.1}", Money::new(Dec!(-0.01), EUR))` stays `-0.0 EUR`).

### Scope

Single site. I checked every sign/zero-sensitive path in the crate:
`Currency`'s Display carries no sign, the `is_positive()` assertion in
`exchange.rs` is a correct precondition (a term amount must be > 0), `Debug`
is derived, serde serialises the amount directly, and the amount type has no
negative zero to propagate. `Money::Display` is the only place that derives a
sign flag for formatting, so this is a localised fix rather than a class.

### Tests

Added a `test_money_zero_sign` module in tests/test_money.rs: zero with the
default/`+`/space flags and non-default minor units, arithmetic-produced zero,
zero under width/fill/precision, non-zero sign regression guards, and a parity
check that `Money`'s Display emits the same sign as the generic `Quantity`
Display for the same amounts.

`cargo test --all-features` — 56 pass, 0 fail (also green with
`--no-default-features` and `--features serde`). `cargo clippy --all-features`
clean.